### PR TITLE
Update test and build dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,4 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
-apply from: 'dependencies.gradle'
-
 buildscript {
     // Gradle will not find vars defined in an external file when referring to them
     // in the buildscript block, unless you link it from the buildscript block, too.
@@ -9,15 +7,14 @@ buildscript {
     repositories {
         google()
         jcenter()
-        
     }
+
     dependencies {
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
         classpath gradlePlugins.kotlin
         classpath gradlePlugins.android
         classpath gradlePlugins.bintrayPlugin
-        classpath gradlePlugins.mavenPlugin
     }
 }
 
@@ -25,7 +22,6 @@ allprojects {
     repositories {
         google()
         jcenter()
-        
     }
 }
 

--- a/contentchef-jvm-callback-common/build.gradle
+++ b/contentchef-jvm-callback-common/build.gradle
@@ -11,7 +11,7 @@ dependencies {
 
     testImplementation libraries.junit
     testImplementation libraries.mockk
-    testCompileOnly libraries.json
+    testImplementation libraries.json
 }
 
 ext {

--- a/contentchef-jvm-common/build.gradle
+++ b/contentchef-jvm-common/build.gradle
@@ -11,7 +11,7 @@ dependencies {
 
     testImplementation libraries.junit
     testImplementation libraries.mockk
-    testCompileOnly libraries.json
+    testImplementation libraries.json
 }
 
 ext {

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -5,7 +5,6 @@ ext.versions = [
         minSdk                       : 14,
         targetSdk                    : 29,
         compileSdk                   : 29,
-        buildTools                   : '29.0.1',
 
         kotlin                       : '1.3.50',
 
@@ -16,8 +15,7 @@ ext.versions = [
         rxAndroid                    : '2.1.1',
 
         androidGradlePlugin          : '4.1.1',
-        bintrayPlugin                : '1.8.4',
-        mavenPlugin                  : '2.1',
+        bintrayPlugin                : '1.8.5',
 
         json                         : '20190722',
 
@@ -28,7 +26,7 @@ ext.versions = [
         junit                        : '4.12',
         testRunner                   : '1.2.0',
         robolectric                  : '4.3.1',
-        mockk                        : '1.9.3',
+        mockk                        : '1.10.5',
         espresso                     : '3.2.0'
 ]
 
@@ -36,7 +34,6 @@ ext.gradlePlugins = [
         android          : "com.android.tools.build:gradle:$versions.androidGradlePlugin",
         kotlin           : "org.jetbrains.kotlin:kotlin-gradle-plugin:$versions.kotlin",
         bintrayPlugin    : "com.jfrog.bintray.gradle:gradle-bintray-plugin:$versions.bintrayPlugin",
-        mavenPlugin      : "com.github.dcendents:android-maven-gradle-plugin:$versions.mavenPlugin"
 ]
 
 ext.libraries = [

--- a/sample-android/build.gradle
+++ b/sample-android/build.gradle
@@ -6,7 +6,6 @@ apply from: '../dependencies.gradle'
 
 android {
     compileSdkVersion versions.compileSdk
-    buildToolsVersion versions.buildTools
 
     defaultConfig {
         applicationId "io.contentchef.android.sample"

--- a/sample-java/build.gradle
+++ b/sample-java/build.gradle
@@ -4,8 +4,6 @@ plugins {
 
 apply from: '../dependencies.gradle'
 
-sourceCompatibility = JavaVersion.VERSION_1_8
-
 repositories {
     mavenCentral()
 }

--- a/sample-kt/build.gradle
+++ b/sample-kt/build.gradle
@@ -5,8 +5,6 @@ plugins {
 
 apply from: '../dependencies.gradle'
 
-sourceCompatibility = 1.8
-
 repositories {
     mavenCentral()
 }
@@ -15,11 +13,4 @@ dependencies {
     implementation libraries.kotlin
 
     implementation project(':contentchef-jvm-callback')
-}
-
-compileKotlin {
-    kotlinOptions.jvmTarget = "1.8"
-}
-compileTestKotlin {
-    kotlinOptions.jvmTarget = "1.8"
 }


### PR DESCRIPTION
Maven plugin external dependency is not needed, now supported by Gradle
Use testImplementation instead of testCompile for libraries.json to make tests run with Gradle
Remove unneeded sourceCompatibility specifications