### PR TITLE
Remove autosync to mavenCentral

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -38,7 +38,7 @@ jobs:
     - name: Build with Gradle
       run: ./gradlew clean build
     - name: Publish to MavenCentral
-      run: ./gradlew publishReleasePublicationToSonatypeRepository --max-workers 1 closeAndReleaseSonatypeStagingRepository
+      run: ./gradlew publishReleasePublicationToSonatypeRepository --max-workers 1
       env:
         CONTENT_CHEF_SIGNING_KEY_ID: ${{ secrets.CONTENT_CHEF_SIGNING_KEY_ID }}
         CONTENT_CHEF_SIGNING_PASSWORD: ${{ secrets.CONTENT_CHEF_SIGNING_PASSWORD }}
@@ -46,3 +46,5 @@ jobs:
         CONTENT_CHEF_OSSRH_USERNAME: ${{ secrets.CONTENT_CHEF_OSSRH_USERNAME }}
         CONTENT_CHEF_OSSRH_PASSWORD: ${{ secrets.CONTENT_CHEF_OSSRH_PASSWORD }}
         CONTENT_CHEF_SONATYPE_STAGING_PROFILE_ID: ${{ secrets.CONTENT_CHEF_SONATYPE_STAGING_PROFILE_ID }}
+    - name: Remember to release to MavenCentral
+      run: echo "Remember to release on MavenCentral from https://s01.oss.sonatype.org"


### PR DESCRIPTION
MavenCentral autosync removed to have the possibility to double check the release