### PR TITLE
fix: Fix 404 empty response body parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ## [Unreleased]
 ### Added
 - A `Locale` can now be provided to `getPreviewChannel` and `getOnlineChannel` to retrieve localized content
+### Fixed
+- Fix `NullPointerException` when a 404 response happens. Now `ContentNotFoundException` it's correctly used 
 
 ## [1.2.2] - 2021-04-30
 ### Added

--- a/contentchef-jvm-common/src/main/java/io/contentchef/common/network/ConnectionStreamReader.kt
+++ b/contentchef-jvm-common/src/main/java/io/contentchef/common/network/ConnectionStreamReader.kt
@@ -1,6 +1,7 @@
 package io.contentchef.common.network
 
 import java.io.BufferedReader
+import java.io.InputStream
 import java.io.InputStreamReader
 import java.net.HttpURLConnection
 
@@ -13,12 +14,21 @@ object ConnectionStreamReader {
      * Returns the content read from [httpURLConnection] as [String]
      */
     fun getContentAsString(httpURLConnection: HttpURLConnection): String {
-        val br = if (httpURLConnection.responseCode in 200..299) {
-            BufferedReader(InputStreamReader(httpURLConnection.inputStream))
-        } else {
-            BufferedReader(InputStreamReader(httpURLConnection.errorStream))
+        return when (httpURLConnection.responseCode) {
+            in 200..299 -> {
+                readStreamAsString(httpURLConnection.inputStream)
+            }
+            404 -> {
+                ""
+            }
+            else -> {
+                readStreamAsString(httpURLConnection.errorStream);
+            }
         }
-        return br.useLines {
+    }
+
+    private fun readStreamAsString(inputStream: InputStream): String {
+        return BufferedReader(InputStreamReader(inputStream)).useLines {
             it.joinToString(separator = "")
         }
     }


### PR DESCRIPTION
Fix `NullPointerException` when a 404 response happens. Now `ContentNotFoundException` it's correctly used 